### PR TITLE
Add speech support to Hangman

### DIFF
--- a/activities/Hangman.activity/index.html
+++ b/activities/Hangman.activity/index.html
@@ -10,6 +10,7 @@
 <link rel="stylesheet" media="screen and (device-width: 1200px) and (device-height: 900px)"
 	href="lib/sugar-web/graphics/css/sugar-200dpi.css">
 <link rel="stylesheet" href="css/activity.css">
+<script src="../Speak.activity/mespeak.js"></script>
 <script data-main="js/loader" src="lib/require.js"></script>
 <script type="text/javascript" src="../../cordova.js"></script>
 </head>

--- a/activities/Hangman.activity/js/activity.js
+++ b/activities/Hangman.activity/js/activity.js
@@ -1,4 +1,4 @@
-define(["sugar-web/activity/activity"], function (activity) {
+define(["sugar-web/activity/activity", "activity/speech"], function (activity, speech) {
 
         var words = [];
         var word, guessed, attempts;
@@ -35,9 +35,11 @@ define(["sugar-web/activity/activity"], function (activity) {
                 if (word.split('').every(function(ch){ return guessed.indexOf(ch) !== -1; })) {
                         status.textContent = 'You win! 😊';
                         status.className = 'win';
+                        speech.speak('You win');
                 } else if (attempts <= 0) {
                         status.textContent = 'Game over: ' + word + ' 😞';
                         status.className = 'lose';
+                        speech.speak('Game over ' + word);
                 }
         }
 
@@ -49,6 +51,7 @@ define(["sugar-web/activity/activity"], function (activity) {
                 status.textContent = '';
                 status.className = '';
                 updateDisplay();
+                speech.speak('New game');
         }
 
         function guess(letter) {
@@ -56,6 +59,7 @@ define(["sugar-web/activity/activity"], function (activity) {
                 if (!letter.match(/^[A-Z]$/) || guessed.indexOf(letter) !== -1) return;
                 guessed.push(letter);
                 if (word.indexOf(letter) === -1) attempts--;
+                speech.speak(letter);
                 updateDisplay();
                 checkResult();
         }

--- a/activities/Hangman.activity/js/speech.js
+++ b/activities/Hangman.activity/js/speech.js
@@ -1,0 +1,29 @@
+define(["sugar-web/env"], function(env) {
+    var configDone = false;
+    var userLanguage = (navigator.language || 'en').substr(0,2);
+
+    env.getEnvironment(function(err, environment) {
+        var defaultLanguage = (typeof window.chrome !== 'undefined' && window.chrome.app && window.chrome.app.runtime) ? window.chrome.i18n.getUILanguage() : navigator.language;
+        if (!environment.user) {
+            environment.user = { language: defaultLanguage };
+        }
+        userLanguage = environment.user.language;
+    });
+
+    function speak(text, language) {
+        if (!configDone) {
+            configDone = true;
+            meSpeak.loadConfig("../Speak.activity/mespeak_config.json");
+        }
+        if (!language) {
+            language = userLanguage;
+        }
+        meSpeak.loadVoice("../Speak.activity/voices/" + language + ".json", function() {
+            meSpeak.speak(text);
+        });
+    }
+
+    return {
+        speak: speak
+    };
+});


### PR DESCRIPTION
## Summary
- enable meSpeak in Hangman activity
- speak on new game, guesses and results

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685d3784a59883318cd5b26ca68799be