### PR TITLE
Add speech support to Hangman

### DIFF
--- a/activities/Hangman.activity/index.html
+++ b/activities/Hangman.activity/index.html
@@ -10,6 +10,7 @@
 <link rel="stylesheet" media="screen and (device-width: 1200px) and (device-height: 900px)"
 	href="lib/sugar-web/graphics/css/sugar-200dpi.css">
 <link rel="stylesheet" href="css/activity.css">
+<script src="../Speak.activity/mespeak.js"></script>
 <script data-main="js/loader" src="lib/require.js"></script>
 <script type="text/javascript" src="../../cordova.js"></script>
 </head>

--- a/activities/Hangman.activity/js/activity.js
+++ b/activities/Hangman.activity/js/activity.js
@@ -1,4 +1,4 @@
-define(["sugar-web/activity/activity"], function (activity) {
+define(["sugar-web/activity/activity", "sugar-web/env", "activity/speech", "l10n"], function (activity, env, speech, l10n) {
 
         var words = [];
         var word, guessed, attempts;
@@ -33,11 +33,13 @@ define(["sugar-web/activity/activity"], function (activity) {
         function checkResult() {
                 var status = document.getElementById('status');
                 if (word.split('').every(function(ch){ return guessed.indexOf(ch) !== -1; })) {
-                        status.textContent = 'You win! 😊';
+                        status.textContent = l10n.get('YouWin') + ' 😊';
                         status.className = 'win';
+                        speech.speak(l10n.get('YouWin'));
                 } else if (attempts <= 0) {
-                        status.textContent = 'Game over: ' + word + ' 😞';
+                        status.textContent = l10n.get('GameOver', {word: word}) + ' 😞';
                         status.className = 'lose';
+                        speech.speak(l10n.get('GameOver', {word: word}));
                 }
         }
 
@@ -49,6 +51,7 @@ define(["sugar-web/activity/activity"], function (activity) {
                 status.textContent = '';
                 status.className = '';
                 updateDisplay();
+                speech.speak(l10n.get('NewGame'));
         }
 
         function guess(letter) {
@@ -56,12 +59,18 @@ define(["sugar-web/activity/activity"], function (activity) {
                 if (!letter.match(/^[A-Z]$/) || guessed.indexOf(letter) !== -1) return;
                 guessed.push(letter);
                 if (word.indexOf(letter) === -1) attempts--;
+                speech.speak(letter);
                 updateDisplay();
                 checkResult();
         }
 
         requirejs(['domReady!'], function () {
                 activity.setup();
+                env.getEnvironment(function(err, environment) {
+                        var defaultLanguage = (typeof chrome != 'undefined' && chrome.app && chrome.app.runtime) ? chrome.i18n.getUILanguage() : navigator.language;
+                        var language = environment.user ? environment.user.language : defaultLanguage;
+                        l10n.init(language);
+                });
                 document.getElementById('new-btn').addEventListener('click', newGame);
                 window.addEventListener('keydown', function(e) {
                         guess(e.key);

--- a/activities/Hangman.activity/js/speech.js
+++ b/activities/Hangman.activity/js/speech.js
@@ -1,0 +1,29 @@
+define(["sugar-web/env"], function(env) {
+    var configDone = false;
+    var userLanguage = (navigator.language || 'en').substr(0,2);
+
+    env.getEnvironment(function(err, environment) {
+        var defaultLanguage = (typeof window.chrome !== 'undefined' && window.chrome.app && window.chrome.app.runtime) ? window.chrome.i18n.getUILanguage() : navigator.language;
+        if (!environment.user) {
+            environment.user = { language: defaultLanguage };
+        }
+        userLanguage = environment.user.language;
+    });
+
+    function speak(text, language) {
+        if (!configDone) {
+            configDone = true;
+            meSpeak.loadConfig("../Speak.activity/mespeak_config.json");
+        }
+        if (!language) {
+            language = userLanguage;
+        }
+        meSpeak.loadVoice("../Speak.activity/voices/" + language + ".json", function() {
+            meSpeak.speak(text);
+        });
+    }
+
+    return {
+        speak: speak
+    };
+});

--- a/activities/Hangman.activity/locales/en.json
+++ b/activities/Hangman.activity/locales/en.json
@@ -1,0 +1,5 @@
+{
+    "NewGame": "New game",
+    "YouWin": "You win",
+    "GameOver": "Game over: {{word}}"
+}

--- a/activities/Hangman.activity/locales/fr.json
+++ b/activities/Hangman.activity/locales/fr.json
@@ -1,0 +1,5 @@
+{
+    "NewGame": "Nouvelle partie",
+    "YouWin": "Vous avez gagné",
+    "GameOver": "Partie terminée : {{word}}"
+}

--- a/activities/Hangman.activity/locales/it.json
+++ b/activities/Hangman.activity/locales/it.json
@@ -1,0 +1,5 @@
+{
+    "NewGame": "Nuova partita",
+    "YouWin": "Hai vinto",
+    "GameOver": "Gioco terminato: {{word}}"
+}


### PR DESCRIPTION
## Summary
- enable meSpeak in Hangman activity
- speak on new game, guesses and results
- localize spoken messages
- add Italian translation

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685d3784a59883318cd5b26ca68799be