### PR TITLE
Add workflow to build Electron packages

### DIFF
--- a/.github/workflows/electron-build.yml
+++ b/.github/workflows/electron-build.yml
@@ -1,0 +1,38 @@
+name: Build Electron Packages
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build-electron:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sugarizer
+        uses: actions/checkout@v3
+        with:
+          path: sugarizer
+
+      - name: Checkout sugarizer-electron
+        uses: actions/checkout@v3
+        with:
+          repository: llaske/sugarizer-electron
+          path: sugarizer-electron
+
+      - name: Build electron packages
+        run: |
+          cd sugarizer-electron
+          chmod +x ./make_electron.sh
+          ./make_electron.sh linux
+
+      - name: Upload Debian package
+        uses: actions/upload-artifact@v3
+        with:
+          name: sugarizer-deb
+          path: sugarizer-electron/**/*.deb
+
+      - name: Upload AppImage
+        uses: actions/upload-artifact@v3
+        with:
+          name: sugarizer-appimage
+          path: sugarizer-electron/**/*.AppImage
+

--- a/.github/workflows/electron-build.yml
+++ b/.github/workflows/electron-build.yml
@@ -27,13 +27,13 @@ jobs:
           ./make_electron.sh linux
 
       - name: Upload Debian package
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: sugarizer-deb
           path: sugarizer-electron/**/*.deb
 
       - name: Upload AppImage
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: sugarizer-appimage
           path: sugarizer-electron/**/*.AppImage

--- a/.github/workflows/electron-build.yml
+++ b/.github/workflows/electron-build.yml
@@ -1,6 +1,8 @@
 name: Build Electron Packages
 
 on:
+  push:
+    branches: ["**"]
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Summary
- create GitHub workflow that checks out `sugarizer-electron`
- run its build script to produce Linux Electron packages
- upload the resulting `.deb` and `.AppImage` files

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686bc10518148331887fd639352fbb4e